### PR TITLE
Trigger autobuild once version is released

### DIFF
--- a/.github/workflows/release-osc-api.yml
+++ b/.github/workflows/release-osc-api.yml
@@ -1,7 +1,7 @@
 name: Outscale API release
 on:
   release:
-    types: published
+    types: [released]
 
 jobs:
   osc-sdk-go:


### PR DESCRIPTION
This avoid to trigger on draft version

Signed-off-by: Jérôme Jutteau <jerome.jutteau@outscale.com>