### PR TITLE
Only execute this Github action on release

### DIFF
--- a/.github/workflows/release-osc-api.yml
+++ b/.github/workflows/release-osc-api.yml
@@ -1,7 +1,7 @@
 name: Outscale API release
 on:
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   osc-sdk-go:


### PR DESCRIPTION
Right now, when a release is published (pre-realease or not), the CI is executed.

Change to released mode following this [documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release)